### PR TITLE
sorted out full/partial evaluation of gradient, tensor, dtensor in model()

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ using DataFrames
 mymodel = model(v-> -dot(v,v), init=ones(3))  
 
 # or for a model providing the gradient : 
-mymodel2 = model(v-> -dot(v,v), v->-2v, init=ones(3))   
+mymodel2 = model(v-> -dot(v,v), grad=v->-2v, init=ones(3))   
 
 ######## Model definition / method 2 = using expression parsing and autodiff
 

--- a/src/modellers/likmodel.jl
+++ b/src/modellers/likmodel.jl
@@ -11,111 +11,59 @@
 
 export MCMCLikModel
 
+typealias FOrNothing 	Union(Nothing, Function)
+typealias ROrVector 	Union(Real, Vector{Float64})
+
+# The likelihood Model type
 type MCMCLikelihoodModel <: MCMCModel
-	eval::Function                 # log-likelihood evaluation function
-	evalg::Union(Nothing,Function) # gradient vector evaluation function
-	evalt::Union(Nothing,Function) # tensor evaluation function
-	evaldt::Union(Nothing,Function) # tensor derivative evaluation function
-  	evalallg::Union(Nothing,Function) # 2-tuple (log-lik, gradient vector) evaluation function
-  	evalallt::Union(Nothing,Function) # 3-tuple (log-lik, gradient vector, tensor) evaluation function
-  	evalalldt::Union(Nothing,Function) # 4-tuple (log-lik, gradient vector, tensor, tensor derivative) evaluation function
+	eval::Function              # log-likelihood evaluation function
+	evalg::FOrNothing 			# gradient vector evaluation function
+	evalt::FOrNothing 			# tensor evaluation function
+	evaldt::FOrNothing 			# tensor derivative evaluation function
+  	evalallg::FOrNothing 		# 2-tuple (log-lik, gradient vector) evaluation function
+  	evalallt::FOrNothing 		# 3-tuple (log-lik, gradient vector, tensor) evaluation function
+  	evalalldt::FOrNothing 		# 4-tuple (log-lik, gradient vector, tensor, tensor derivative) evaluation function
 	pmap::PMap                     # map to/from parameter vector from/to user-friendly variables
 	size::Integer                  # parameter vector size
 	init::Vector{Float64}          # parameter vector initial values
 	scale::Vector{Float64}         # scaling hint on parameters
 
-	MCMCLikelihoodModel(	f::Function, 
-		g::Union(Nothing, Function), 
-		t::Union(Nothing, Function),
-		dt::Union(Nothing, Function),
-		i::Vector{Float64}, sc::Vector{Float64}, pmap::PMap) = begin
+	MCMCLikelihoodModel(f::Function, 
+						g::FOrNothing, ag::FOrNothing,
+						t::FOrNothing, at::FOrNothing,
+						dt::FOrNothing, adt::FOrNothing,
+						i::Vector{Float64}, 
+						sc::Vector{Float64}, 
+						pmap::PMap) = begin
 
 		s = size(i, 1)
 
 		assert(ispartition(pmap, s), "param map is not a partition of parameter vector")
 		assert(size(sc,1) == s, "scale parameter size ($(size(sc,1))) different from initial values ($s)")
 
-		# check that likelihood function can be called with a vector of Float64 as argument
-		assert(hasvectormethod(f), "likelihood function cannot be called with Vector{Float64}")
-
-		# check that gradient function can be called with a vector of Float64 as argument
-		assert(g == nothing || hasvectormethod(g), "gradient function cannot be called with Vector{Float64}")
-
-		# check that tensor function can be called with a vector of Float64 as argument
-		assert(t == nothing || hasvectormethod(t), "tensor function cannot be called with Vector{Float64}")
-
-		# check that tensor derivative function can be called with a vector of Float64 as argument
-		assert(dt == nothing || hasvectormethod(dt), "tensor derivative function cannot be called with Vector{Float64}")
+		# check that all functions can be called with a vector of Float64 as argument
+		for ff in [f, g, ag, t, at, dt, adt]
+			assert(ff==nothing || hasvectormethod(f), 
+					"one of the supplied functions cannot be called with Vector{Float64}")
+			#TODO : make error message print which function is problematic
+		end
 
 		# check that initial values are in the support of likelihood function
 		assert(isfinite(f(i)), "Initial values out of model support, try other values")
 
-		instance = new()
-		instance.eval = f
-		instance.evalt = t
-		instance.evaldt = dt
-		instance.init = i
-		instance.scale = sc
-		instance.pmap =pmap
-		instance.size = s
-
-		# to find out if gradient g returns a tuple (llik, gradient) or a gradient only
-		#  TODO : this should be improved !
-		res = g(i)
-		if isa(res, Vector)
-			instance.evalg = g
-			instance.evalallg = (pars::Vector{Float64} -> (instance.eval(pars), instance.evalg(pars)))
-		elseif isa(res, Tuple)
-			instance.evalallg = g
-			instance.evalg = (pars::Vector{Float64} -> instance.evalallg(pars)[2])
-		end
-
-		instance.evalallt = (pars::Vector{Float64} -> (instance.eval(pars), instance.evalg(pars), instance.evalt(pars)))
-		instance.evalalldt = (pars::Vector{Float64} -> (instance.eval(pars), instance.evalg(pars), instance.evalt(pars), instance.evaldt(pars)))
-
-		instance
+		new(f, g, t, dt, ag, at, adt, pmap, s, i, sc)
 	end
 end
 
 typealias MCMCLikModel MCMCLikelihoodModel
-
-# Model creation : gradient or tensor or tensor derivative not specified
-MCMCLikelihoodModel( lik::Function; args...) = 
-	MCMCLikelihoodModel(lik, nothing, nothing, nothing; args...)
-MCMCLikelihoodModel( lik::Function, grad::Function; args...) = 
-	MCMCLikelihoodModel(lik, grad, nothing, nothing; args...)
-MCMCLikelihoodModel( lik::Function, grad::Function, tensor::Function; args...) = 
-	MCMCLikelihoodModel(lik, grad, tensor, nothing; args...)
-
-# Model creation : gradient+tensor+tensor derivative version 
-function MCMCLikelihoodModel(	lik::Function, 
-								grad::Union(Nothing, Function), 
-								tensor::Union(Nothing, Function),
-								dtensor::Union(Nothing, Function); 
-								init::Union(Real, Vector{Float64}) = [1.0], 
-								scale::Union(Real, Vector{Float64}) = 1.0,
-								pmap::Union(Nothing, PMap) = nothing) 
-
-	# convert init to vector if needed
-	init = isa(init, Real) ? [init] : init
-
-	# expand scale to parameter vector size if needed
-	scale = isa(scale, Real) ? scale * ones(length(init)) : scale
-
-	# all parameters named "pars" by default
-	pmap = pmap == nothing ? Dict([:pars], [PDims(1, size(init))]) : pmap 
-
-	MCMCLikelihoodModel(lik, grad, tensor, dtensor, init, scale, pmap)
-end
 
 # Model creation using expression parsing and autodiff
 function MCMCLikelihoodModel(	m::Expr; 
 								gradient::Bool=false,
 								init=nothing,
 								pmap=nothing,
-								scale::Union(Real, Vector{Float64}) = 1.0,
+								scale::ROrVector = 1.0,
 								args...)
-
 	# when using expressions, initial values are passed in keyword args
 	#  with one arg by parameter, therefore there is not need for an init arg
 	assert(init == nothing, "'init' kwargs not allowed for model as expression\n")
@@ -133,5 +81,53 @@ function MCMCLikelihoodModel(	m::Expr;
 		g = nothing
 	end
 
-	MCMCLikelihoodModel(f, g, nothing, nothing; init=i, pmap=p, scale=scale)
+	MCMCLikelihoodModel(f, allgrad=g, init=i, pmap=p, scale=scale)
 end
+
+
+# Model creation : with user supplied functions
+function MCMCLikelihoodModel(	lik::Function;
+								grad::FOrNothing = nothing, 
+								tensor::FOrNothing = nothing,
+								dtensor::FOrNothing = nothing,
+								allgrad::FOrNothing = nothing, 
+								alltensor::FOrNothing = nothing,
+								alldtensor::FOrNothing = nothing,
+								init::ROrVector = [1.0], 
+								scale::ROrVector = 1.0,
+								pmap::Union(Nothing, PMap) = nothing) 
+
+	# convert init to vector if needed
+	init = isa(init, Real) ? [init] : init
+
+	# expand scale to parameter vector size if needed
+	scale = isa(scale, Real) ? scale * ones(length(init)) : scale
+
+	# all parameters named "pars" by default
+	if pmap == nothing ; pmap = Dict([:pars], [PDims(1, size(init))]) ; end 
+
+	# now build missing functions, if any
+	fmat = Array(FOrNothing, 3, 2)
+	for (i, f1, f2) in [(1, grad, allgrad), 
+						(2, tensor, alltensor), 
+						(3, dtensor, alldtensor)]
+		fmat[i,:] = [f1 f2]
+		if f1==nothing && f2!=nothing # only the tuple version is supplied
+			fmat[i,1] = (v) -> f2(v)[end] 
+		elseif f1!=nothing && f2==nothing # only the single version is supplied
+			if i == 1
+				fmat[i,2] = (v) -> (lik(v), f1(v))
+			else
+				assert(isa(fmat[i-1,2], Function), "missing function !")
+				fmat[i,2] = (v) -> tuple(fmat[i-1,2](v)..., f1(v))
+			end
+		end
+	end
+
+	MCMCLikelihoodModel(lik, 
+						fmat[1,1], fmat[1,2],
+						fmat[2,1], fmat[2,2],
+						fmat[3,1], fmat[3,2],
+						init, scale, pmap)
+end
+

--- a/src/modellers/mcmcmodels.jl
+++ b/src/modellers/mcmcmodels.jl
@@ -9,8 +9,6 @@ export MCMCLikModel, model
 ### Model types hierarchy to allow restrictions on applicable samplers
 abstract Model
 abstract MCMCModel <: Model
-# abstract MCMCModelWithGradient <: MCMCModel
-# abstract MCMCModelWithHessian <: MCMCModelWithGradient
 
 ######### parameters map info  ############
 # These types are used to map scalars in the
@@ -20,7 +18,6 @@ immutable PDims
 	pos::Integer   # starting position of parameter in the parameter vector
 	dims::Tuple    # dimensions of user facing parameter, can be a scalar, vector or matrix
 end
-
 typealias PMap Dict{Symbol, PDims}
 
 function ispartition(m::PMap, n::Integer)
@@ -39,43 +36,11 @@ hasdtensor{M<:MCMCModel}(m::M) = m.evaldt != nothing
 
 #### User-facing model creation function  ####
 
-# TODO
-
-function model(f::Function; mtype="likelihood", args...)
+# Currently only a "likelihood" model type makes sense
+# Left as is in case other kind of models come up
+function model(f::Union(Function, Expr); mtype="likelihood", args...)
 	if mtype == "likelihood"
 		return MCMCLikelihoodModel(f; args...)
-	elseif mtype == "whatever"
-	else
-	end
-end
-
-function model(f1::Function, f2::Function; mtype="likelihood", args...)
-	if mtype == "likelihood"
-		return MCMCLikelihoodModel(f1, f2; args...)
-	elseif mtype == "whatever"
-	else
-	end
-end
-
-function model(f1::Function, f2::Function, f3::Function; mtype="likelihood", args...)
-	if mtype == "likelihood"
-		return MCMCLikelihoodModel(f1, f2, f3; args...)
-	elseif mtype == "whatever"
-	else
-	end
-end
-
-function model(f1::Function, f2::Function, f3::Function, f4::Function; mtype="likelihood", args...)
-	if mtype == "likelihood"
-		return MCMCLikelihoodModel(f1, f2, f3, f4; args...)
-	elseif mtype == "whatever"
-	else
-	end
-end
-
-function model(m::Expr; mtype="likelihood", args...)
-	if mtype == "likelihood"
-		return MCMCLikelihoodModel(m::Expr; args...)
 	elseif mtype == "whatever"
 	else
 	end

--- a/test/test_dists.jl
+++ b/test/test_dists.jl
@@ -34,6 +34,7 @@ function ksTest(ex::Expr)
 
 	for (k,v) in {	"RWM" => RWM(exactStd),
 					"HMC" => HMC(2, exactStd/5),
+					"MALA" => MALA(exactStd),
 					"NUTS" => NUTS()}  # TODO : add other samplers
 		print("testing $k sampler on $ex   -")
 		srand(1)

--- a/test/test_syntax.jl
+++ b/test/test_syntax.jl
@@ -2,6 +2,7 @@
 #    testing script for simple examples 
 #########################################################################
 
+using Base.Test
 using MCMC
 
 # generate a random dataset
@@ -33,4 +34,57 @@ res = m * RWM() * (100:1000)
 res = run(m * RWM(), steps=1000, thinning=10, burnin=0)
 res = run(m, HMC(2,0.1), thinning=10, burnin=0)
 res = run(m, HMC(2,0.1), burnin=20)
+
+
+
+
+
+### README examples 
+
+mymodel = model(v-> -dot(v,v), init=ones(3))  
+mymodel2 = model(v-> -dot(v,v), grad = v->-2v, init=ones(3))   
+
+modexpr = quote
+    v ~ Normal(0, 1)
+end
+
+mymodel = model(modexpr, v=ones(3)) # without gradient
+mymodel2 = model(modexpr, gradient=true, v=ones(3)) # with gradient
+
+res = run(mymodel * RWM(0.1), steps=1000, burnin=100)
+res = run(mymodel * RWM(0.1), steps=1000, burnin=100, thinning=5)
+res = run(mymodel * RWM(0.1), steps=101:5:1000)
+res = mymodel * RWM(0.1) * (101:5:1000)  
+
+head(res.samples)
+describe(res.samples)
+head(res.diagnostics)
+
+res = run(res, steps=10000)  
+
+
+@test_throws mymodel * MALA(0.1) * (1:1000) # throws an error 
+
+mymodel2 * MALA(0.1) * (1:1000) # now this works
+
+res = run(mymodel2 * [RWM(0.1), MALA(0.1), HMC(3,0.1)], steps=1000) 
+res[2].samples  # prints samples for MALA(0.1)
+
+res = run(mymodel2 * [HMC(i,0.1) for i in 1:5], steps=1000)
+
+nmod = 10  # number of models
+mods = Array(MCMCLikModel, nmod)
+sts = logspace(1, -1, nmod)
+for i in 1:nmod
+	m = quote
+		y = abs(x)
+		y ~ Normal(1, $(sts[i]) )
+	end
+	mods[i] = model(m, x=0)
+end
+
+targets = MCMCTask[ mods[i] * RWM(sts[i]) for i in 1:nmod ]
+particles = [ [randn()] for i in 1:1000]
+
+res = seqMC(targets, particles, steps=10, burnin=0)  
 


### PR DESCRIPTION
Now, the user can call model() with any combination of single (only a gradient, only a tensor, etc..) and multiple (functions returning tuples (likelihood, gradient), (likelihood, gradient, tensor), etc..) functions; provided that when a tensor (resp. dtensor) is given there is also a gradient (resp. tensor) function too.

All current tests pass.

Note to self : tests should be updated to verify all combinations
