### PR TITLE
replace rep with repeat

### DIFF
--- a/src/runners/SeqMC.jl
+++ b/src/runners/SeqMC.jl
@@ -104,7 +104,7 @@ function run_seqmc(targets::Array{MCMCTask}; particles::Vector{Vector{Float64}} 
 	MCMCChain((burnin+1):1:((steps-burnin)*npart),
 	  samples',
 		nothing,
-		{"weigths" => weights, "particle" => repeat([1:npart]; outer=[steps-burnin])},
+		{"weigths" => weights, "particle" => repeat([1:npart], outer=[steps-burnin])},
 		targets,
 		toq())
 end


### PR DESCRIPTION
I guess `rep` must have previously existed and no longer does? Or there's an unstated dependency? Anyway, I believe my change has the intended behavior.

I ran into this running Example 2 from the README, and until this change I got this error:

ERROR: rep not defined
 in run_seqmc at /Users/david/.julia/MCMC/src/runners/SeqMC.jl:104
 in run at /Users/david/.julia/MCMC/src/runners/runners.jl:28
