### PR TITLE
added logtargets field in MCMCChain

### DIFF
--- a/src/MCMC.jl
+++ b/src/MCMC.jl
@@ -58,28 +58,42 @@ include("samplers/SliceSampler.jl")  # Slice sampler
 type MCMCChain
   range::Range{Int}
   samples::Matrix{Float64}
+  logtargets::Vector{Float64}
   gradients::MatrixF64OrNothing
   diagnostics::Dict
   task::Union(MCMCTask, Array{MCMCTask})
   runTime::Float64
    
-  function MCMCChain(r::Range{Int}, s::Matrix{Float64}, g::MatrixF64OrNothing, d::Dict,
-    t::Union(MCMCTask, Array{MCMCTask}), rt::Float64)
+  function MCMCChain(r::Range{Int}, 
+                     s::Matrix{Float64}, 
+                     l::Vector{Float64}, 
+                     g::MatrixF64OrNothing, 
+                     d::Dict,
+                     t::Union(MCMCTask, Array{MCMCTask}),
+                     rt::Float64)
+    @assert size(s,1) == size(l,1) "samples and logtargets do not have the same size"
     if g != nothing
       @assert size(s) == size(g) "samples and gradients must have the same number of rows and columns"
     end
-    new(r, s, g, d, t, rt)
+    new(r, s, l, g, d, t, rt)
   end
 end
 
-MCMCChain(r::Range{Int}, s::Matrix{Float64}, d::Dict, t::Union(MCMCTask, Array{MCMCTask}), rt::Float64) = 
-	MCMCChain(r, s, nothing, d, t, rt)
-MCMCChain(r::Range{Int}, s::Matrix{Float64}, t::Union(MCMCTask, Array{MCMCTask}), rt::Float64) = 
-	MCMCChain(r, s, nothing, Dict(), t, rt)
-MCMCChain(r::Range{Int}, s::Matrix{Float64}, d::Dict, t::Union(MCMCTask, Array{MCMCTask})) = 
-	MCMCChain(r, s, nothing, d, t, NaN)
-MCMCChain(r::Range{Int}, s::Matrix{Float64}, t::Union(MCMCTask, Array{MCMCTask})) = 
-	MCMCChain(r, s, nothing, Dict(), t, NaN)
+MCMCChain(r::Range{Int}, s::Matrix{Float64}, l::Vector{Float64}, 
+          d::Dict, t::Union(MCMCTask, Array{MCMCTask}), rt::Float64) = 
+	MCMCChain(r, s, l, nothing,      d, t,    rt)
+
+MCMCChain(r::Range{Int}, s::Matrix{Float64}, l::Vector{Float64}, 
+          t::Union(MCMCTask, Array{MCMCTask}), rt::Float64) = 
+	MCMCChain(r, s, l, nothing, Dict(), t,    rt)
+
+MCMCChain(r::Range{Int}, s::Matrix{Float64}, l::Vector{Float64}, 
+          d::Dict, t::Union(MCMCTask, Array{MCMCTask})) = 
+	MCMCChain(r, s, l, nothing,      d, t,   NaN)
+
+MCMCChain(r::Range{Int}, s::Matrix{Float64}, l::Vector{Float64}, 
+          t::Union(MCMCTask, Array{MCMCTask})) = 
+	MCMCChain(r, s, l, nothing, Dict(), t,   NaN)
 
 function show(io::IO, res::MCMCChain)
   nsamples, npars = size(res.samples)

--- a/src/runners/SerialTempMC.jl
+++ b/src/runners/SerialTempMC.jl
@@ -44,7 +44,10 @@ function run_serialtempmc(tasks::Array{MCMCTask})
 	map(t -> consume(t.task), tasks)
 
 	# initialize MCMCChain result (one Chain only)
-	res = MCMCChain(1:1:2, fill(NaN, tsize, steps-burnin), tasks[end])
+	res = MCMCChain(1:1:2, 
+	                fill(NaN, tsize, steps-burnin), 
+	                fill(NaN, steps-burnin), 
+	                tasks[end])
 
 	local logW = zeros(nmods)  # log of task weights that will be adapted
 	local at = 1  # pick starting task
@@ -69,12 +72,12 @@ function run_serialtempmc(tasks::Array{MCMCTask})
 		end
 
 		# TODO : add logW adaptation
-
 		ppars, logtarget, pars = s.ppars, s.logtarget, s.pars
 
 		if i > burnin # store ppars and the model we're on
 			pos = i-burnin 
 			res.samples[:, pos] = ppars
+			res.logtargets[pos] = logtarget
 			#res.misc[:mod][pos] = at
 		end
 	end


### PR DESCRIPTION
In response to #48 

I added a `logtargets` field to the MCMCChain type and adapted SerialMC, SeqMC, SerialTempMC.
`runtests.jl` passes, so does travis. (note : I have not added tests specific to this field, I just checked them on a few runs.)

@scidom if it is ok with you, i'll merge it in master and tag MCMC at 0.0.6.
