### PR TITLE
Fix julia 0.4 warnings

### DIFF
--- a/src/Lora.jl
+++ b/src/Lora.jl
@@ -11,7 +11,8 @@ import Base:
   select,
   mean,
   var,
-  std
+  std,
+  +
 import Distributions:
   Bernoulli,
   Beta,

--- a/src/parsers/definitions/MCMCDerivRules.jl
+++ b/src/parsers/definitions/MCMCDerivRules.jl
@@ -11,12 +11,12 @@ macro dlogpdfd(dist::Symbol, rule)
 	ReverseDiffSource.deriv_rule( sig, :d, rule ) 
 
 	sig = :( logpdf($(Expr(:(::), :d, dist)), x::AbstractArray) )
-	rule2 = ReverseDiffSource.substSymbols(rule, {:x => :(x[i]), :ds => :(ds[i])})
+	rule2 = ReverseDiffSource.substSymbols(rule, Dict{Any,Any}(:x => :(x[i]), :ds => :(ds[i])))
 	ReverseDiffSource.deriv_rule( sig, :d, :(for i in 1:length(x) ; $rule2 ; end))
 
 	sig = :( logpdf($(Expr(:(::), :d, Expr(:curly, :Array, dist))), x::AbstractArray) )
-	rule2 = ReverseDiffSource.substSymbols(rule, {:dd1 => :(dd1[i]), :dd2 => :(dd2[i]), :dd3 => :(dd3[i]), 
-		:x => :(x[i]), :ds => :(ds[i]), :d => :(d[i]) })
+	rule2 = ReverseDiffSource.substSymbols(rule, Dict{Any,Any}(:dd1 => :(dd1[i]), :dd2 => :(dd2[i]), :dd3 => :(dd3[i]), 
+		:x => :(x[i]), :ds => :(ds[i]), :d => :(d[i]) ))
 	ReverseDiffSource.deriv_rule(sig, :d, :(for i in 1:length(x) ; $rule2 ; end))
 end
 
@@ -25,11 +25,11 @@ macro dlogpdfx(dist::Symbol, rule)
 	ReverseDiffSource.deriv_rule( sig, :x, rule ) 
 
 	sig = :( logpdf($(Expr(:(::), :d, dist)), x::AbstractArray) )
-	rule2 = ReverseDiffSource.substSymbols(rule, {:dx => :(dx[i]), :x => :(x[i]), :ds => :(ds[i])})
+	rule2 = ReverseDiffSource.substSymbols(rule, Dict{Any,Any}(:dx => :(dx[i]), :x => :(x[i]), :ds => :(ds[i])))
 	ReverseDiffSource.deriv_rule( sig, :x, :(for i in 1:length(x) ; $rule2 ; end))
 
 	sig = :( logpdf($(Expr(:(::), :d, Expr(:curly, :Array, dist))), x::AbstractArray) )
-	rule3 = ReverseDiffSource.substSymbols(rule2, {:d => :(d[i])})
+	rule3 = ReverseDiffSource.substSymbols(rule2, Dict{Any,Any}(:d => :(d[i])))
 	ReverseDiffSource.deriv_rule( sig, :x, :(for i in 1:length(x) ; $rule3 ; end))
 end
 

--- a/test/test_slice_sampler.jl
+++ b/test/test_slice_sampler.jl
@@ -14,7 +14,7 @@ function funnel_loglik(x::Vector{Float64})
     -0.5*((x[1]-0.0)^2/9.0 + dot(x[2:end], x[2:end])/s2 + nx*log(s2))
 end
 
-mcmodel = model(funnel_loglik, init=[10, zeros(4)])
+mcmodel = model(funnel_loglik, init=[10, zeros(4);])
 mcsampler = SliceSampler()
 mcrunner = SerialMC(nsteps=100000, burnin=10000)
 mcchain = run(mcmodel, mcsampler, mcrunner)


### PR DESCRIPTION
This fixes depreciation warnings on the julia 0.4 release candiate. Would be great if a new release at 0.4.x could be tagged with these patches. 

I didn't make this julia 0.3 compatible, given that the 0.4.x Lora series is julia 0.4 only anyways.