### PR TITLE
Update Travis to include 0.5, don't override default script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,10 +4,12 @@ os:
     - osx
 julia:
     - 0.4
+    - 0.5
+    - nightly
 notifications:
     email: false
 sudo: false
-script:
-    - if [[ -a .git/shallow ]]; then git fetch --unshallow; fi
-    - julia -e 'Pkg.clone(pwd())'
-    - julia -e 'Pkg.test("Lora", coverage=true)'
+# script:
+#     - if [[ -a .git/shallow ]]; then git fetch --unshallow; fi
+#     - julia -e 'Pkg.clone(pwd())'
+#     - julia -e 'Pkg.test("Lora", coverage=true)'


### PR DESCRIPTION
Julia 0.5 is now a release. Since the REQUIRE doesn't have an upper bound on the required Julia version for installation, we should be running CI on the 0.5 release and on the nightlies. It's also better not to override the default test script unless there's a particular reason to do so, so I commented that part out.